### PR TITLE
Adding Python 3.11 to the GH workflow

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -8,22 +8,34 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runtime.platform }}
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        
+        runtime:
+          - python: '3.6'
+            platform: 'ubuntu-20.04'
+          - python: '3.7'
+            platform: 'ubuntu-latest'
+          - python: '3.8'
+            platform: 'ubuntu-latest'
+          - python: '3.9'
+            platform: 'ubuntu-latest'
+          - python: '3.10'
+            platform: 'ubuntu-latest'
+          - python: '3.11'
+            platform: 'ubuntu-latest'
+
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
-    
+        python-version: ${{ matrix.runtime.python }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -33,7 +45,7 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        
+
     - name: Build
       run: |
         python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 transit-python2
 ==============
 
-*Forked from [transit-python](https://github.com/cognitect/transit-python). Python 3.6 to 3.10 are supported*
+*Forked from [transit-python](https://github.com/cognitect/transit-python). Python 3.6 to 3.11 are supported*
 
 Transit is a format and set of libraries for conveying values between
 applications written in different programming languages. The library provides


### PR DESCRIPTION
Hey! 👋🏻 

I have been using this project with Python `3.11` for a few weeks in production, and it's working fine so far. So, I decided to open this pull request to update the GitHub workflow and README to make it clear that this project supports the new version.

Any concerns/suggestions are welcome! Please let me know what you think.